### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is still a work in progress and is mostly meant to be for education
 Make sure you have [go](https://golang.org/) installed.
 
 ```bash
-$ go get https://github.com/gtr/ivy
+$ go get github.com/gtr/ivy
 $ cd $GOPATH/src/github.com/gtr/ivy/
 $ go build
 $ ./ivy file [options]


### PR DESCRIPTION
removed the "https://" to avoid the error if you try to copy and paste that first command

"invalid import path: malformed import path "https:/github.com/gtr/ivy": invalid char ':'" 

this might be trivial but since theres no prebuilt releases why not consider a shell script?